### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/201/291/421201291.geojson
+++ b/data/421/201/291/421201291.geojson
@@ -271,6 +271,9 @@
     },
     "wof:country":"BL",
     "wof:created":1459010068,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de9a8fdd08300ee9422e7767900d69c3",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
         }
     ],
     "wof:id":421201291,
-    "wof:lastmodified":1566615559,
+    "wof:lastmodified":1582347048,
     "wof:name":"Marigot",
     "wof:parent_id":85669283,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.