### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/201/291/421201291.geojson
+++ b/data/421/201/291/421201291.geojson
@@ -119,6 +119,9 @@
     "name:ita_x_preferred":[
         "Marigot"
     ],
+    "name:jpn_x_preferred":[
+        "\u30de\u30ea\u30b4"
+    ],
     "name:kon_x_preferred":[
         "Marigot"
     ],
@@ -286,7 +289,7 @@
         }
     ],
     "wof:id":421201291,
-    "wof:lastmodified":1582347048,
+    "wof:lastmodified":1690858665,
     "wof:name":"Marigot",
     "wof:parent_id":85669283,
     "wof:placetype":"locality",

--- a/data/421/201/293/421201293.geojson
+++ b/data/421/201/293/421201293.geojson
@@ -20,6 +20,9 @@
     "name:afr_x_preferred":[
         "Gustavia"
     ],
+    "name:ara_x_preferred":[
+        "\u063a\u0648\u0633\u062a\u0627\u0641\u064a\u0627"
+    ],
     "name:arg_x_preferred":[
         "Gustavia"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0443\u0441\u0442\u0430\u0432\u0456\u044f"
+    ],
+    "name:bel_x_variant":[
+        "\u0413\u0443\u0441\u0442\u0430\u0432\u0456\u044f"
     ],
     "name:ben_x_preferred":[
         "\u0997\u09c1\u09b8\u09cd\u09a4\u09ad\u09bf\u09af\u09bc\u09be"
@@ -58,6 +64,9 @@
     ],
     "name:ces_x_preferred":[
         "Gustavia"
+    ],
+    "name:che_x_preferred":[
+        "\u0413\u0443\u0441\u0442\u0430\u0432\u0438\u044f"
     ],
     "name:cos_x_preferred":[
         "Gustavia"
@@ -125,6 +134,9 @@
     "name:guj_x_preferred":[
         "\u0a97\u0ac1\u0ab8\u0acd\u0a9f\u0abe\u0ab5\u0abf\u0a86"
     ],
+    "name:heb_x_preferred":[
+        "\u05d2\u05d5\u05e1\u05d8\u05d1\u05d9\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u0917\u0941\u0938\u094d\u0924\u093e\u0935\u093f\u092f\u093e"
     ],
@@ -178,6 +190,9 @@
     ],
     "name:kor_x_variant":[
         "\uad6c\uc2a4\ud0c0\ube44\uc544"
+    ],
+    "name:lat_x_preferred":[
+        "Gustavia"
     ],
     "name:lav_x_preferred":[
         "Gustavija"
@@ -420,7 +435,7 @@
         }
     ],
     "wof:id":421201293,
-    "wof:lastmodified":1566615559,
+    "wof:lastmodified":1690858665,
     "wof:name":"Gustavia",
     "wof:parent_id":85669283,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.